### PR TITLE
fix(validate): Interpret all 2xx status codes as successful responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -101,7 +101,7 @@ func commonRequest(cli *Client, method string, u string, body requestBody) ([]by
 		return nil, stacktrace.Propagate(err, "failed to read response body from %s", u)
 	}
 
-	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		err := ErrorUnexpectedResponse{
 			StatusCode: resp.StatusCode,
 			URL:        u,


### PR DESCRIPTION
The validate command is failing trying to parse JSON from the response because the status code is a `204` and there's no content when validation succeeds. This should prevent us from getting into that condition allowing the command to complete successfully.