### PR TITLE
feat(publish): add a flag to force publishing a config

### DIFF
--- a/cmd/spinmd/main.go
+++ b/cmd/spinmd/main.go
@@ -155,7 +155,11 @@ func main() {
 			mdcli.AssumeEnvName(envName),
 		)
 	case "publish":
-		exitCode, err = mdcli.Publish(opts)
+		var force bool
+		publishFlags := flag.NewFlagSet("diff", flag.ExitOnError)
+		publishFlags.BoolVar(&force, "force", false, "allow overwriting existing resources when publishing the config for the first time")
+		publishFlags.Parse(args[1:])
+		exitCode, err = mdcli.Publish(opts, force)
 	case "validate":
 		exitCode, err = mdcli.Validate(opts)
 	case "diff":

--- a/cmd/spinmd/main.go
+++ b/cmd/spinmd/main.go
@@ -156,7 +156,7 @@ func main() {
 		)
 	case "publish":
 		var force bool
-		publishFlags := flag.NewFlagSet("diff", flag.ExitOnError)
+		publishFlags := flag.NewFlagSet("publish", flag.ExitOnError)
 		publishFlags.BoolVar(&force, "force", false, "allow overwriting existing resources when publishing the config for the first time")
 		publishFlags.Parse(args[1:])
 		exitCode, err = mdcli.Publish(opts, force)

--- a/deliveryconfig.go
+++ b/deliveryconfig.go
@@ -774,7 +774,7 @@ func (p *DeliveryConfigProcessor) UpdateArtifactReference(content *[]byte, updat
 
 // Publish will post the delivery config to the Spinnaker API so that Spinnaker
 // will update the Managed state for the application.
-func (p *DeliveryConfigProcessor) Publish(cli *Client) error {
+func (p *DeliveryConfigProcessor) Publish(cli *Client, force bool) error {
 	if p.rawDeliveryConfig == nil {
 		err := p.Load()
 		if err != nil {
@@ -782,7 +782,7 @@ func (p *DeliveryConfigProcessor) Publish(cli *Client) error {
 		}
 	}
 
-	_, err := commonRequest(cli, "POST", "/managed/delivery-configs", requestBody{
+	_, err := commonRequest(cli, "POST", fmt.Sprintf("/managed/delivery-configs?force=%t", force), requestBody{
 		Content:     bytes.NewReader(p.content),
 		ContentType: "application/x-yaml",
 	})

--- a/mdcli/publish.go
+++ b/mdcli/publish.go
@@ -47,7 +47,8 @@ func (body *PublishErrorBody) UnmarshalJSON(b []byte) error {
 
 // Publish is a command line interface for publishing a local delivery config
 // to be managed by Spinnaker.
-func Publish(opts *CommandOptions) (int, error) {
+func Publish(opts *CommandOptions, force bool) (int, error) {
+	fmt.Printf("It is recommended to update your delivery config by committing it to your repository and not by calling the publish command. For more details: http://go.netflix.com/publish-managed-delivery-config")
 	configPath := filepath.Join(opts.ConfigDir, opts.ConfigFile)
 	if _, err := os.Stat(configPath); err != nil {
 		return 1, err
@@ -63,7 +64,7 @@ func Publish(opts *CommandOptions) (int, error) {
 		mdlib.WithFile(opts.ConfigFile),
 	)
 
-	err := mdProcessor.Publish(cli)
+	err := mdProcessor.Publish(cli, force)
 	if err != nil {
 		if e, ok := stacktrace.RootCause(err).(mdlib.ErrorUnexpectedResponse); ok {
 			pe := &PublishError{}

--- a/mdcli/publish_test.go
+++ b/mdcli/publish_test.go
@@ -26,7 +26,7 @@ func TestPublish(t *testing.T) {
 	opts.ConfigDir = "../test-files/publish"
 	opts.ConfigFile = "spinnaker.yml"
 
-	_, err := Publish(opts)
+	_, err := Publish(opts, false)
 	require.NoError(t, err)
 
 	// we expect a single POST to delivery-configs API

--- a/mdcli/publish_test.go
+++ b/mdcli/publish_test.go
@@ -31,6 +31,6 @@ func TestPublish(t *testing.T) {
 
 	// we expect a single POST to delivery-configs API
 	require.Equal(t, map[string]int{
-		"POST /managed/delivery-configs": 1,
+		"POST /managed/delivery-configs?force=false": 1,
 	}, requests)
 }


### PR DESCRIPTION
We decided to add a flag that allows users to force publishing a config and overwriting existing resources if the app is not managed already (if the app is managed, it does not do anything). 
In other words, if `force=false`, i.e. the default value, and the app is not managed, MD will throw an error when publishing a new config