### PR TITLE
remove print on publish

### DIFF
--- a/mdcli/publish.go
+++ b/mdcli/publish.go
@@ -48,7 +48,6 @@ func (body *PublishErrorBody) UnmarshalJSON(b []byte) error {
 // Publish is a command line interface for publishing a local delivery config
 // to be managed by Spinnaker.
 func Publish(opts *CommandOptions, force bool) (int, error) {
-	fmt.Printf("It is recommended to update your delivery config by committing it to your repository and not by calling the publish command. For more details: http://go.netflix.com/publish-managed-delivery-config")
 	configPath := filepath.Join(opts.ConfigDir, opts.ConfigFile)
 	if _, err := os.Stat(configPath); err != nil {
 		return 1, err


### PR DESCRIPTION
we forgot a newline on the print, this also breaks it up for better console formatting and uses the configured Stdout.
