### PR TITLE
Switch from github.com/palantir/stacktrace to golang.org/x/xerrors

### DIFF
--- a/cmd/spinmd/main.go
+++ b/cmd/spinmd/main.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/palantir/stacktrace"
 	mdlib "github.com/spinnaker/md-lib-go"
 	"github.com/spinnaker/md-lib-go/mdcli"
 	"github.com/spinnaker/spin/cmd/gateclient"
@@ -216,7 +215,7 @@ func main() {
 	}
 
 	if err != nil {
-		log.Fatalf("ERROR: %s", stacktrace.RootCause(err))
+		log.Fatalf("ERROR: %s", err)
 	}
 	os.Exit(exitCode)
 }

--- a/export.go
+++ b/export.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/palantir/stacktrace"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -131,7 +131,7 @@ func FindApplicationResources(cli *Client, appName string) (*ApplicationResource
 
 	err := g.Wait()
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "failed to load resources")
+		return nil, xerrors.Errorf("failed to load resources: %w", err)
 	}
 
 	return data, nil
@@ -203,11 +203,11 @@ func ExportArtifact(cli *Client, resource *ExportableResource, result interface{
 		requestBody{},
 	)
 	if err != nil {
-		return stacktrace.Propagate(err, "")
+		return xerrors.Errorf("failed to retrieve artifact YAML: %w", err)
 	}
 	err = yaml.Unmarshal(content, result)
 	if err != nil {
-		return stacktrace.Propagate(ErrorInvalidContent{Content: content, ParseError: err}, "")
+		return xerrors.Errorf("failed to unmarshal artifact YAML: %w", ErrorInvalidContent{Content: content, ParseError: err})
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.0.7
 	github.com/coryb/walky v0.0.0-20210615011224-0cbbf739e255
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
-	github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177
 	github.com/spinnaker/spin v0.4.1-0.20200522004912-3fb5d26378a8
 	github.com/stretchr/testify v1.7.0
 	github.com/xlab/treeprint v1.0.0
 	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/client-go v11.0.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,6 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177 h1:nRlQD0u1871kaznCnn1EvYiMbum36v7hw1DLPEjds4o=
-github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177/go.mod h1:ao5zGxj8Z4x60IOVYZUbDSmt3R8Ddo080vEgPosHpak=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -193,6 +191,8 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/mdcli/export.go
+++ b/mdcli/export.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mgutz/ansi"
-	"github.com/palantir/stacktrace"
 	mdlib "github.com/spinnaker/md-lib-go"
 	"github.com/xlab/treeprint"
 	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -251,7 +251,7 @@ func Export(opts *CommandOptions, appName string, serviceAccount string, overrid
 		opts.Logger.Printf("Exporting %s", resource)
 		content, err := exportOpts.customResourceExporter(cli, resource, serviceAccount)
 		if err != nil {
-			errors = append(errors, stacktrace.Propagate(err, "Failed to export resource %s", resource))
+			errors = append(errors, xerrors.Errorf("Failed to export resource %s: %w", resource, err))
 			continue
 		}
 
@@ -278,7 +278,7 @@ func Export(opts *CommandOptions, appName string, serviceAccount string, overrid
 				survey.WithStdio(opts.Stdin, opts.Stdout, opts.Stderr),
 			)
 			if err != nil {
-				errors = append(errors, stacktrace.Propagate(err, "Failed to read prompt for environment on resource %s", resource))
+				errors = append(errors, xerrors.Errorf("Failed to read prompt for environment on resource %s: %w", resource, err))
 				continue
 			}
 			envName = selectedEnvironment
@@ -287,7 +287,7 @@ func Export(opts *CommandOptions, appName string, serviceAccount string, overrid
 
 		added, err := mdProcessor.UpsertResource(resource, envName, content)
 		if err != nil {
-			errors = append(errors, stacktrace.Propagate(err, "Failed to upsert delivery config for resource %s", resource))
+			errors = append(errors, xerrors.Errorf("Failed to upsert delivery config for resource %s: %w", resource, err))
 			continue
 		}
 		modifiedResources[resource] = added
@@ -323,7 +323,7 @@ func Export(opts *CommandOptions, appName string, serviceAccount string, overrid
 					}
 					added, err = mdProcessor.UpsertResource(resource, envName, content)
 					if err != nil {
-						errors = append(errors, stacktrace.Propagate(err, "Failed to upsert delivery config for resource %s", resource))
+						errors = append(errors, xerrors.Errorf("Failed to upsert delivery config for resource %s: %w", resource, err))
 						continue
 					}
 					modifiedResources[resource] = added

--- a/mdcli/publish.go
+++ b/mdcli/publish.go
@@ -2,11 +2,11 @@ package mdcli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/palantir/stacktrace"
 	mdlib "github.com/spinnaker/md-lib-go"
 )
 
@@ -65,7 +65,8 @@ func Publish(opts *CommandOptions, force bool) (int, error) {
 
 	err := mdProcessor.Publish(cli, force)
 	if err != nil {
-		if e, ok := stacktrace.RootCause(err).(mdlib.ErrorUnexpectedResponse); ok {
+		var e mdlib.ErrorUnexpectedResponse
+		if errors.As(err, &e) {
 			pe := &PublishError{}
 			e.Parse(pe)
 			fmt.Fprintf(opts.Stderr, "ERROR: Failed to publish delivery config.  Spinnaker responded with:\n")


### PR DESCRIPTION
`github.com/palantir/stacktrace` hasn't been updated since 2016 and
doesn't support modern error wrapping conventions (`Is`/`As`/`Unwrap`).
`golang.org/x/errors` is a more official package with similar features,
which does conform to these conventions.