### PR TITLE
Change "Update" to "Export" in output

### DIFF
--- a/mdcli/export.go
+++ b/mdcli/export.go
@@ -189,7 +189,7 @@ func Export(opts *CommandOptions, appName string, serviceAccount string, overrid
 		var option string
 		switch {
 		case mdProcessor.ResourceExists(resource):
-			option = fmt.Sprintf("Update %s", resource)
+			option = fmt.Sprintf("Export %s", resource)
 		case resource.ResourceType == mdlib.NetworkLoadBalancerResourceType:
 			opts.Logger.Printf("WARNING cannot export %s", resource)
 			continue


### PR DESCRIPTION
We got feedback from a user that: "Update <resource>" was confusing
because it sounded like the export would modify the resource.

Updating the language to indicate it's an export, not a modification of
the resource.