### PR TITLE
chore(cli): Remove deprecated use of service accounts

### DIFF
--- a/cmd/spinmd/main.go
+++ b/cmd/spinmd/main.go
@@ -129,30 +129,23 @@ func main() {
 	exitCode := 0
 	switch args[0] {
 	case "export":
-		var appName, serviceAccount string
+		var appName string
 		exportAll := false
 		envName := ""
 
 		exportFlags := flag.NewFlagSet("export", flag.ExitOnError)
 		exportFlags.StringVar(&appName, "app", "", "spinnaker application name")
-		exportFlags.StringVar(&serviceAccount, "service-account", "", "spinnaker service account")
 		exportFlags.BoolVar(&exportAll, "all", false, "export all options, skip prompt")
 		exportFlags.StringVar(&envName, "env", "", "assign exported resources to given environment, skip prompt")
 		exportFlags.Parse(args[1:])
 
-		if exportFlags.NArg() > 0 || appName == "" || serviceAccount == "" {
-			fmt.Printf("Usage: export -app <name> -service-account <account>\n")
+		if exportFlags.NArg() > 0 || appName == "" {
+			fmt.Printf("Usage: export -app <name>\n")
 			fmt.Printf("Flags:\n")
 			exportFlags.Usage()
 			return
 		}
-		exitCode, err = mdcli.Export(
-			opts,
-			appName,
-			serviceAccount,
-			mdcli.ExportAll(exportAll),
-			mdcli.AssumeEnvName(envName),
-		)
+		exitCode, err = mdcli.Export(opts, appName, mdcli.ExportAll(exportAll), mdcli.AssumeEnvName(envName))
 	case "publish":
 		var force bool
 		publishFlags := flag.NewFlagSet("publish", flag.ExitOnError)

--- a/deliveryconfig.go
+++ b/deliveryconfig.go
@@ -35,11 +35,10 @@ var (
 
 // DeliveryConfig holds the structure for the manage delivery config stored in .netflix/spinnaker.yml
 type DeliveryConfig struct {
-	Name           string
-	Application    string
-	ServiceAccount string `yaml:"serviceAccount"`
-	Artifacts      []*DeliveryArtifact
-	Environments   []*DeliveryEnvironment
+	Name         string
+	Application  string
+	Artifacts    []*DeliveryArtifact
+	Environments []*DeliveryEnvironment
 }
 
 // DeliveryEnvironment contains the resources per environment.
@@ -185,7 +184,6 @@ type DeliveryResourceContainer struct {
 // DeliveryConfigProcessor is a structure to manage operations on a delivery config.
 type DeliveryConfigProcessor struct {
 	appName               string
-	serviceAccount        string
 	fileName              string
 	dirName               string
 	rawDeliveryConfig     *yaml.Node
@@ -247,13 +245,6 @@ func WithFile(f string) ProcessorOption {
 func WithAppName(a string) ProcessorOption {
 	return func(p *DeliveryConfigProcessor) {
 		p.appName = a
-	}
-}
-
-// WithServiceAccount is a ProcessorOption to set the service account used for access control for the delivery config operations.
-func WithServiceAccount(a string) ProcessorOption {
-	return func(p *DeliveryConfigProcessor) {
-		p.serviceAccount = a
 	}
 }
 
@@ -368,11 +359,6 @@ func (p *DeliveryConfigProcessor) Save() error {
 		appNode, _ := walky.ToNode(p.appName)
 		walky.AssignMapNode(p.rawDeliveryConfig, keyNode, appNode)
 	}
-	if ok := walky.HasKey(p.rawDeliveryConfig, "serviceAccount"); !ok && p.serviceAccount != "" {
-		keyNode, _ := walky.ToNode("serviceAccount")
-		serviceAccountNode, _ := walky.ToNode(p.serviceAccount)
-		walky.AssignMapNode(p.rawDeliveryConfig, keyNode, serviceAccountNode)
-	}
 	// ensure if no artifacts are present then we set it to an empty list, it is
 	// required by the API
 	if !walky.HasKey(p.rawDeliveryConfig, "artifacts") {
@@ -442,7 +428,6 @@ var ConfigKeySortPriority = []string{
 	"container",
 	"locations",
 	"application",
-	"serviceAccount",
 	"artifacts",
 	"environments",
 }

--- a/export.go
+++ b/export.go
@@ -178,14 +178,13 @@ func ExportableApplicationResources(appData *ApplicationResources) []*Exportable
 
 // ExportResource will contact the Spinnaker REST API to collect the YAML delivery config representation for
 // a specific resource.
-func ExportResource(cli *Client, resource *ExportableResource, serviceAccount string) ([]byte, error) {
+func ExportResource(cli *Client, resource *ExportableResource) ([]byte, error) {
 	return commonRequest(cli, "GET",
-		fmt.Sprintf("/managed/resources/export/%s/%s/%s/%s?serviceAccount=%s",
+		fmt.Sprintf("/managed/resources/export/%s/%s/%s/%s",
 			resource.CloudProvider,
 			resource.Account,
 			resource.ResourceType,
 			resource.Name,
-			serviceAccount,
 		),
 		requestBody{},
 	)

--- a/mdcli/export_test.go
+++ b/mdcli/export_test.go
@@ -55,7 +55,6 @@ func TestExport(t *testing.T) {
 	_, err = Export(
 		opts,
 		"myapp",
-		"myteam@example.com",
 		AssumeEnvName("testing"),
 		ExportAll(true),
 	)

--- a/test-files/diff/responses/managed/delivery-configs/diff/POST.json
+++ b/test-files/diff/responses/managed/delivery-configs/diff/POST.json
@@ -10,7 +10,6 @@
           "apiVersion": "ec2.spinnaker.netflix.com/v1",
           "kind": "security-group",
           "metadata": {
-            "serviceAccount": "myteam@example.com",
             "id": "ec2:security-group:test:myapp",
             "uid": "01234567890123456789",
             "application": "myapp"
@@ -83,7 +82,6 @@
           "apiVersion": "titus.spinnaker.netflix.com/v1",
           "kind": "cluster",
           "metadata": {
-            "serviceAccount": "myteam@example.com",
             "id": "titus:cluster:titustest:myapp",
             "uid": "01234567890123456789",
             "application": "myapp"

--- a/test-files/diff/spinnaker.yml
+++ b/test-files/diff/spinnaker.yml
@@ -81,4 +81,3 @@ environments:
       moniker:
         app: myapp
 name: myapp-manifest
-serviceAccount: myteam@example.com

--- a/test-files/export/spinnaker.yml.expected
+++ b/test-files/export/spinnaker.yml.expected
@@ -1,5 +1,4 @@
 application: myapp
-serviceAccount: myteam@example.com
 artifacts:
   - name: myapp
     type: deb

--- a/test-files/publish/spinnaker.yml
+++ b/test-files/publish/spinnaker.yml
@@ -91,4 +91,3 @@ environments:
       moniker:
         app: myapp
 name: myapp-manifest
-serviceAccount: myteam@example.com


### PR DESCRIPTION
We no longer require/use service accounts at Netflix. To the best of me knowledge, there's no one outside of Netflix using this library. A perhaps obvious question that follows is whether we should fork this code like we did the rest of the Spinnaker repos so we can change it as we please without the fear of impacting others.